### PR TITLE
fix: min size 16px font size on inputs for mobile

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -181,7 +181,12 @@
 		@media (min-width: 640px) {
 			font-size: 16px;
 		}
+
+		input {
+			font-size: 16px;
+		}
 	}
+
 
 	body {
 		height: 100%;

--- a/src/lib/components/search/command.svelte
+++ b/src/lib/components/search/command.svelte
@@ -30,7 +30,7 @@
 </Button>
 
 <Command.Dialog bind:open shouldFilter={false}>
-	<Command.Input placeholder="Search..." bind:value={searchQuery} />
+	<Command.Input placeholder="Search..." bind:value={searchQuery} class="text-[16px]" />
 	<Command.List>
 		<Command.Empty>No results found.</Command.Empty>
 		{#if searchResults.loading}


### PR DESCRIPTION
Fixes issue of mobile taps on inputs zooming the screen by setting font size to 16px.